### PR TITLE
correct path of image_file

### DIFF
--- a/sample_z_dog.html
+++ b/sample_z_dog.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Zdog Tutorial</title>
+  <script src="https://unpkg.com/zdog@1/dist/zdog.dist.min.js"></script>
+</head>
+<body>
+  <canvas width="240" height="240" class="zdog-canvas"></canvas>
+  <script>
+    // ここにコードを記述
+    const illo = new Zdog.Illustration({
+    element: '.zdog-canvas',
+    dragRotate: true    // ←これを追加
+    })
+
+    // 円を追加
+    //new Zdog.Ellipse({
+    //addTo: illo,
+    //diameter: 80,    // 直径
+    //stroke: 20,      // 線の太さ
+    //color: '#E62'    // 図形の色
+    //})
+    var polygon = new Zdog.Polygon({
+        addTo: illo,
+        translate: { x: 0 }, // 
+        radius: 60,
+        sides: 5,
+        stroke: 20,
+        color: '#EA0',
+    });
+
+    new Zdog.Shape({
+        addTo: illo,
+        translate: { x: -30, y: -60 }, // 
+        stroke: 20,
+        color: '#636',
+    });
+
+    new Zdog.Shape({
+        addTo: illo,
+        translate: { x: 30, y: -60 }, // 
+        stroke: 20,
+        color: '#636',
+    });
+
+    new Zdog.Shape({
+        addTo: illo,
+        path: [
+            { x: 60 ,y: -20}, // start at 1st point
+            { x: 100 ,y: -30 }, // line to 2nd point
+        ],
+        stroke: 10,
+        color: '#636',
+    })
+    new Zdog.Shape({
+        addTo: illo,
+        path: [
+            { x: -60 ,y: -20}, // start at 1st point
+            { x: -100 ,y: -30 }, // line to 2nd point
+        ],
+        stroke: 10,
+        color: '#636',
+    })
+    new Zdog.Shape({
+        addTo: illo,
+        path: [
+            { x: 40 ,y: 50}, // start at 1st point
+            { x: 60 ,y: 80 }, // line to 2nd point
+        ],
+        stroke: 10,
+        color: '#636',
+    })
+    new Zdog.Shape({
+        addTo: illo,
+        path: [
+            { x: -40 ,y: 50}, // start at 1st point
+            { x: -60 ,y: 80 }, // line to 2nd point
+        ],
+        stroke: 10,
+        color: '#636',
+    })
+    // 図形を描画
+    illo.updateRenderGraph()
+    const animate = () => {
+        illo.rotate.x += 0.03
+        illo.rotate.y += 0.03             // 図形を回転
+        illo.updateRenderGraph()          // 回転後の図形を描画
+
+        requestAnimationFrame( animate )  // 再度呼び出し
+    }
+    animate()
+  </script>
+</body>
+</html>

--- a/start.html
+++ b/start.html
@@ -10,7 +10,8 @@
       <sectiona>
         <div id = content>
           <div class="box">
-            <p class="btn"><a href="index.html">About</a></p>
+            <p class="btn" id = btn_0><a href="index.html">About</a></p>
+            <p class="btn" id = btn_1 role="button"><a href="sample_z_dog.html">3D_graphic</a></p>
             <img src="IMG_0151.JPG">
           </div>
         </div>

--- a/start.html
+++ b/start.html
@@ -11,7 +11,7 @@
         <div id = content>
           <div class="box">
             <p class="btn"><a href="index.html">About</a></p>
-            <img src="/home/minato/デスクトップ/20190630_minato_project_1/my_profile/IMG_0151.JPG">
+            <img src="IMG_0151.JPG">
           </div>
         </div>
       </section>

--- a/sty_0.css
+++ b/sty_0.css
@@ -12,7 +12,7 @@ p{
     font-family: 'Noto Sans JP', sans-serif;
     color: #ffffff;
 }
- .btn a {
+ .btn#btn_0 a {
      background-color: #618556;
      color:#ffffff;
      font-size: 30px;
@@ -25,12 +25,30 @@ p{
      border-radius: 5px;
      border: 3px solid #000000;
 }
+.btn#btn_1 a {
+    background-color: #618556;
+    color:#ffffff;
+    font-size: 30px;
+    font-family: 'Noto Sans JP', sans-serif;
+    width: 170px;
+    display: block;
+    text-align: center;
+    line-height: 50px;
+    margin-top: 20px;
+    border-radius: 5px;
+    border: 3px solid #000000;
+}
  .btn a:hover {
      text-decoration: none;
      background-color: #ffffff;
      color: #36abc0;
      text-shadow: 2px -2px 1px #000000
  }
+
+#btn_1{
+    width: 150px;
+ }
+
 img{
     max-width: 70%;
     max-height: 70%;


### PR DESCRIPTION
# start.htmlに記述されていた画像ファイルのパスを修正
2019/07/11(木)
## 問題点
* 画層ファイルのパスが開発者の環境の絶対パスになっていて，今回私が本リポジトリを`git clone`してきて，htmlファイルを確認するとstart.htmlに記載されるはずの画像ファイルが読み込まれなかった．
## 解決策
* 画像ファイルのパスを，htmlファイルが置かれているディレクトリからの相対パスで記述することで，環境に依存しないように画像ファイルを読み込むことができるようにした．